### PR TITLE
feat(mergesort): baseline + reuse buffer + cutoff + tests

### DIFF
--- a/src/main/java/com/alikhan_s/algos/sort/MergeSort.java
+++ b/src/main/java/com/alikhan_s/algos/sort/MergeSort.java
@@ -1,0 +1,60 @@
+package com.alikhan_s.algos.sort;
+
+import java.util.Arrays;
+
+public class MergeSort {
+    private static final int CUTOFF = 16; // small-n cutoff for insertion sort
+    private final int[] buffer;
+
+    public MergeSort(int n) {
+        this.buffer = new int[n]; // reusable buffer
+    }
+
+    public void sort(int[] arr) {
+        sort(arr, 0, arr.length - 1);
+    }
+
+    private void sort(int[] arr, int left, int right) {
+        if (right - left <= CUTOFF) {
+            insertionSort(arr, left, right);
+            return;
+        }
+
+        int mid = left + (right - left) / 2;
+        sort(arr, left, mid);
+        sort(arr, mid + 1, right);
+        merge(arr, left, mid, right);
+    }
+
+    private void merge(int[] arr, int left, int mid, int right) {
+        // copy to buffer
+        System.arraycopy(arr, left, buffer, left, right - left + 1);
+
+        int i = left, j = mid + 1, k = left;
+        while (i <= mid && j <= right) {
+            if (buffer[i] <= buffer[j]) {
+                arr[k++] = buffer[i++];
+            } else {
+                arr[k++] = buffer[j++];
+            }
+        }
+        while (i <= mid) {
+            arr[k++] = buffer[i++];
+        }
+        while (j <= right) {
+            arr[k++] = buffer[j++];
+        }
+    }
+
+    private void insertionSort(int[] arr, int left, int right) {
+        for (int i = left + 1; i <= right; i++) {
+            int key = arr[i];
+            int j = i - 1;
+            while (j >= left && arr[j] > key) {
+                arr[j + 1] = arr[j];
+                j--;
+            }
+            arr[j + 1] = key;
+        }
+    }
+}

--- a/src/test/java/com/alikhan_s/algos/sort/MergeSortTest.java
+++ b/src/test/java/com/alikhan_s/algos/sort/MergeSortTest.java
@@ -1,0 +1,56 @@
+package com.alikhan_s.algos.sort;
+
+import org.junit.jupiter.api.Test;
+import java.util.Random;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+
+class MergeSortTest {
+
+    @Test
+    void testSmallArray() {
+        int[] arr = {5, 2, 4, 6, 1, 3};
+        int[] expected = arr.clone();
+        java.util.Arrays.sort(expected);
+
+        MergeSort sorter = new MergeSort(arr.length);
+        sorter.sort(arr);
+
+        assertArrayEquals(expected, arr);
+    }
+
+    @Test
+    void testLargeRandomArray() {
+        Random random = new Random();
+        int n = 1000;
+        int[] arr = random.ints(n, -10000, 10000).toArray();
+        int[] expected = arr.clone();
+        java.util.Arrays.sort(expected);
+
+        MergeSort sorter = new MergeSort(arr.length);
+        sorter.sort(arr);
+
+        assertArrayEquals(expected, arr);
+    }
+
+    @Test
+    void testAlreadySorted() {
+        int[] arr = {1, 2, 3, 4, 5};
+        int[] expected = arr.clone();
+
+        MergeSort sorter = new MergeSort(arr.length);
+        sorter.sort(arr);
+
+        assertArrayEquals(expected, arr);
+    }
+
+    @Test
+    void testSingleElement() {
+        int[] arr = {42};
+        int[] expected = {42};
+
+        MergeSort sorter = new MergeSort(arr.length);
+        sorter.sort(arr);
+
+        assertArrayEquals(expected, arr);
+    }
+}


### PR DESCRIPTION
### Summary
Implemented MergeSort with divide-and-conquer approach:
- Recursive baseline implementation
- Linear merge with reusable buffer
- Cutoff to insertion sort for small subarrays
- Comprehensive JUnit5 test coverage

### Technical notes
- `MergeSort` class uses a preallocated buffer to reduce memory allocations
- Cutoff threshold set to 16 elements (tunable constant)
- Insertion sort improves performance on small subarrays
- Tested with small arrays, large random arrays, sorted input, and single element

### How to test
- Run `mvn test` → all MergeSort tests should pass
- Compare performance vs. Java’s built-in `Arrays.sort()` on random arrays
